### PR TITLE
Fix Cognito invitation email parameter

### DIFF
--- a/infrastructure/lib/features/api.ts
+++ b/infrastructure/lib/features/api.ts
@@ -78,7 +78,7 @@ export class dt_api extends Construct {
 		let userInvitation: undefined | object = undefined;
 		userInvitation = {
 			emailSubject: 'Invite to log into City Trax Translate',
-			emailBody: 'Hello {given_name}, you have been invited to log in to City Trax Translate.  Your temporary password is {####}'
+			emailBody: 'Hello {username}, you have been invited to log in to City Trax Translate.  Your temporary password is {####}'
 		};
 		let mfa: undefined | cognito.Mfa = undefined;
 		switch (props.cognitoLocalUsersMfa) {


### PR DESCRIPTION
Parameter must be {username}; cannot be any other user attribute.